### PR TITLE
Updates to clicked class assignment and display of txtDOT panel

### DIFF
--- a/EventHandlerConditionals.txt
+++ b/EventHandlerConditionals.txt
@@ -15,18 +15,21 @@ Event Handler Conditionals - i.e., non-standard behavior functions
 1) if: user has selected states && then user clicks a state that IS in the selected states group,
 	then: Keep selected, discard clicked (default)      
 	
+	- Rebecca: Fixed this by commenting out lines 174-182 and lines 185-188; uncommeting line 172; adding line 166 (with comment on line 165). Before adding the "clicked" class to the newly clicked "selectedClass", just change the currently "clicked" class so that it no longer has "clicked" class (and just has "selectedClass").  6/26/2015
 	- as of 6/24/15 discard clicked is not working which because click is not getting assigned to the clicked state in the selected states group	  
 	- earlier failure: Selected is successfully kept, but clicked instances are kept on previously clicked states within the selected states group, resulting in more than one state appearing as if the clicked state. Fixed it by commenting out line 160 return classNames + " clicked"	
 
 2) if: user has selected states && user then clicks a state that IS NOT one of the selected states,
 	then: Discard selected, discard clicked (default)      
 	
+	- Rebecca: for some reason, this didn't seem to be working, so I added and if statement on line 159 (with comment on 158). 6/26/2015
 	- this already works 6/9/15
 
 TO DO:	  
 3) if: clicked class doesn't exist anywhere on the map, 
 	then: Remove or hide the text under map
 
+	- Rebecca: I updated the code so that whenever the drop-down menu selection is changed, it automatically hides the txtDOT panel. Then, I moved the $("#txtDOT").show(); line within the click event, so that the content is updated/shown whenever the user clicks on a state with class="selectedClass.  Commented out lines 33-44; added lines 17-18; moved line 37 to line 169.  6/26/2015
 	- Not working yet as of 6/24/15. Tie to an event handler?
 
 
@@ -37,12 +40,14 @@ TO DO:
 1) if: user has clicked any state && user then selects states which may or may not include the clicked state,
 	then: discard clicked (default)   
 
+	- Rebecca: Hmm... not sure if I messed this up or not.  Let me know and I'll troubleshoot.  6/26/2015
 	-this works 6/24/15 (notwithstanding that clicked doesn't get assigned on selected states)    
 	  
 TO DO:
 2) if: selectedClass doesn't exist, 
 	then: reset menu.
 
+	- Rebecca: I'm not sure about this one.  Would there be a reset button to trigger the removal of selectedClass?  6/26/2015
 	- Not programmed yet as of 6/24/15. Tie to an event handler?
 		
 	

--- a/exploreMap.html
+++ b/exploreMap.html
@@ -919,7 +919,7 @@
 <!--}-->
 <!--fill-opacity: 0.5;-->
 <!--stroke-width=0.5!important;-->
-}
+<!-- } -->
 <!--.clicked text {-->
 <!--stroke-width:5.0;-->
 <!--}-->

--- a/exploreMap.js
+++ b/exploreMap.js
@@ -12,8 +12,11 @@ $( document ).ready( function(){
         //WHEN USER SELECTS FROM DROP DOWN MENU
         $( "#productOptions" ).on( "change", function(e) {
 
-        //WHEN USER SELECTS FROM THE DROP DOWN MENU - ATTRIBUTES FUNCTION. Always discard existing clicked class first.
-            $(".clicked").attr("class","");
+            //WHEN USER SELECTS FROM THE DROP DOWN MENU - ATTRIBUTES FUNCTION. Always discard existing clicked class first.
+            $(".clicked").attr("class", "");
+            // Then, hide previously displayed content
+            $("#txtDOT").hide();
+
             $(".selectedClass").attr("class", function(index, classNames) {
                 // if the selectedClass elements already have other existing classes. ¸
                 if (typeof classNames != "undefined") {
@@ -27,18 +30,18 @@ $( document ).ready( function(){
             });//closing for $(".selectedClass").attr("class", function(index, classNames) {
 
             //HIDE TEXT BOX - 6/24 look again at failed code in discardClicked1st...
-            $(this).attr("class", function(index,classNames){
-                if (typeof classNames != "undefined") {
-//                if ( $("g").hasClass("clicked") ) {
-                console.log("clicked exists so show txtDOT");//logged 8 (8 out of 51 state DOTs)
-                $("#txtDOT").show();//but unfortunately, the text stays off even after click class returns!
-//                });
-                }
-                else {
-                console.log("clicked doesn't exist so hide txtDOT");//43 (43 out of 51 state DOTs)
-                $("txtDOT").hide();
-                }
-            });
+//             $(this).attr("class", function(index,classNames){
+//                 if (typeof classNames != "undefined") {
+// //                if ( $("g").hasClass("clicked") ) {
+//                 console.log("clicked exists so show txtDOT");//logged 8 (8 out of 51 state DOTs)
+//                 $("#txtDOT").show();//but unfortunately, the text stays off even after click class returns!
+// //                });
+//                 }
+//                 else {
+//                 console.log("clicked doesn't exist so hide txtDOT");//43 (43 out of 51 state DOTs)
+//                 $("txtDOT").hide();
+//                 }
+//             });
 
             //THE DROP DOWN MENU TEXT OBJECT CREATION AND FILTER FUNCTIONALITY
             var selected = $( "#productOptions option:selected" ).text();
@@ -152,28 +155,37 @@ $( document ).ready( function(){
 
         //WHEN USER CLICKS ON A STATE
         $("g").on( "click", function ( e ) {
+            // checks to see if the state clicked actually has the "selectedClass" so that it will only display information on states clicked with the "selectedClass"
+            if (($(this).attr("class")) == ("selectedClass")) {
 
-        //WHEN USER CLICKS ON A STATE - ATTRIBUTES FUNCTION. Always discard existing clicked class first
-        //$( this ).off( "click" );//this line only lets user click on a state one time. try some other method.
-        $(this).attr("class", function(index, classNames) {
-            if ( typeof classNames != "undefined" ) { // if there are existing classes
-//                return classNames + " clicked";//comment this line out and clicked won't accrue on selected states
+            //WHEN USER CLICKS ON A STATE - ATTRIBUTES FUNCTION. Always discard existing clicked class first
+            //$( this ).off( "click" );//this line only lets user click on a state one time. try some other method.
+            $(this).attr("class", function(index, classNames) {
+                if ( typeof classNames != "undefined" ) { // if there are existing classes
+                   // before assigning "clicked" class to the newly clicked on "selectedClass", remove it from the previously clicked class
+                   $(".clicked").attr("class", "selectedClass");
 
-                //function that removes previously clicked class instances from sibling states. gets the ~returned clicked~ class attribute and checks for existing classes on the "g" element
-                $(this).siblings("g").attr("class", function(index, classNames) {
-                    if (typeof classNames != "undefined") {// if there are existing classes on the siblings
-                        return classNames.replace("clicked", "");// return the existing classes and remove just the clicked class
-                    }
-                    else {// if there are not existing classes on the siblings
-                        return classNames;
-                    }
-                 });
-            }
+                   // Show the corresponding text after the user clicks on a state, but before the return statement
+                   $("#txtDOT").show();
+                   
+                   // don't have to worry about "clicked" class accruing on "selectedClass" now because of line above
+                   return classNames + " clicked";
 
-            else {
-            // if typeof classNames is undefined, meaning there aren't any existing classes, add the class clicked outright to the selected g element and remove the class from its siblings
-            $(this).attr("class", "clicked").siblings("g").removeAttr("class");//removeAttr only takes one arg, says Reed
-            }
+                    //function that removes previously clicked class instances from sibling states. gets the ~returned clicked~ class attribute and checks for existing classes on the "g" element
+                    // $(this).siblings("g").attr("class", function(index, classNames) {
+                    //     if (typeof classNames != "undefined") {// if there are existing classes on the siblings
+                    //         return classNames.replace("clicked", "");// return the existing classes and remove just the clicked class
+                    //     }
+                    //     else {// if there are not existing classes on the siblings
+                    //         return classNames;
+                    //     }
+                    //  });
+                }
+
+                //else {
+                // if typeof classNames is undefined, meaning there aren't any existing classes, add the class clicked outright to the selected g element and remove the class from its siblings
+               // $(this).attr("class", "clicked").siblings("g").removeAttr("class");//removeAttr only takes one arg, says Reed
+               // }
         });//closing for $(this).attr("class", function(index, classNames) {
 
             //PARSE DATA, CREATE TEXT OBJECTS
@@ -246,6 +258,8 @@ $( document ).ready( function(){
                 }
 
             });//closing for $.each(data,function(key,val){
+
+            } // closing for if has "selectedClass" statement
 
         });//closing for $( "g" )on( "click", function(e){
 

--- a/productMenu.js
+++ b/productMenu.js
@@ -5,6 +5,10 @@ $( document ).ready( function(){
 //      console.log ( data );//whole JSON object
 
         $( "#productOptions" ).change( function( e ) {//.on can only bind to one function and .on is used on clicked g already. use .bind to bind ~?an el~? to multiple functions. Can .change do multiple events? it better or replace it.
+            // Remove selectedClass before making any new selections
+            // SVGs are weird and won't let you explicitly remove a class, so you just use empty quotes instead
+            $('.selectedClass').attr('class','');
+            
             var selected = $("#productOptions option:selected").text();  //$spans.eq( 3 ).text( jQuery.inArray( "Pete", arr, 2 ) );
 //            console.log( "user selected " + selected );
 //            console.log( typeof selected );//string

--- a/productMenu.js
+++ b/productMenu.js
@@ -5,6 +5,18 @@ $( document ).ready( function(){
 //      console.log ( data );//whole JSON object
 
         $( "#productOptions" ).change( function( e ) {//.on can only bind to one function and .on is used on clicked g already. use .bind to bind ~?an el~? to multiple functions. Can .change do multiple events? it better or replace it.
+            // look for elements with .selectedClass and check for other existing classes
+        	$(".selectedClass").attr("class", function(index, classNames) {
+        	    // if the element does have other existing classes
+				if (typeof classNames != "undefined") {
+				    // return the list of classnames and just remove the .selectedClass
+					return classNames.replace("selectedClass", "");
+				} else {
+				    // otherwise, remove the class
+					$(".selectedClass").attr("class", "");
+				}
+			});
+            
             var selected = $("#productOptions option:selected").text();  //$spans.eq( 3 ).text( jQuery.inArray( "Pete", arr, 2 ) );
 //            console.log( "user selected " + selected );
 //            console.log( typeof selected );//string
@@ -61,7 +73,20 @@ $( document ).ready( function(){
 //                                        $productStates.css( "fill-opacity", "0.1" );//SUCCESS, but how to remove styling from unselected g's?
 //                                        $productStates = $productStates.attr("class","selectedClass");//class appears on tag but not actually styled with opacity change
 //                                        $productStates = $productStates.attr("class","selectedClass").siblings( "g" ).removeAttr( "class","selectedClass" );//class appears but quickly removes itself
-                                        $productStates.attr("class","selectedClass");//.siblings( "g" ).removeAttr( "class","selectedClass" );//class appears on tag but not actually styled with opacity change
+                                       
+                                       // check $productStates for existing classes
+                                       	$productStates.attr('class', function(index, classNames) {
+                                       	    // if there are existing classes
+											if (typeof classNames != 'undefined') {
+											    // return the existing classes and add selectedClass to the end of the list
+												return classNames + ' selectedClass';
+											} else {
+											    // otherwise, just add selectedClass
+												$productStates.attr('class', 'selectedClass');	
+											}
+										});
+                                       
+                                       // $productStates.attr("class","selectedClass");//.siblings( "g" ).removeAttr( "class","selectedClass" );//class appears on tag but not actually styled with opacity change
                                         //for line above, I indented one more tab in from where it was and now selectedClass is again appearing on tags but not actually styling the g's.
 //                                        $productStates = $productStates.addClass( "selectedClass" );//nothing. earlier today, style=("fill-opacity","0.1") got tacked onto appropriate g tags
 

--- a/productMenu.js
+++ b/productMenu.js
@@ -5,18 +5,6 @@ $( document ).ready( function(){
 //      console.log ( data );//whole JSON object
 
         $( "#productOptions" ).change( function( e ) {//.on can only bind to one function and .on is used on clicked g already. use .bind to bind ~?an el~? to multiple functions. Can .change do multiple events? it better or replace it.
-            // look for elements with .selectedClass and check for other existing classes
-        	$(".selectedClass").attr("class", function(index, classNames) {
-        	    // if the element does have other existing classes
-				if (typeof classNames != "undefined") {
-				    // return the list of classnames and just remove the .selectedClass
-					return classNames.replace("selectedClass", "");
-				} else {
-				    // otherwise, remove the class
-					$(".selectedClass").attr("class", "");
-				}
-			});
-            
             var selected = $("#productOptions option:selected").text();  //$spans.eq( 3 ).text( jQuery.inArray( "Pete", arr, 2 ) );
 //            console.log( "user selected " + selected );
 //            console.log( typeof selected );//string
@@ -73,20 +61,7 @@ $( document ).ready( function(){
 //                                        $productStates.css( "fill-opacity", "0.1" );//SUCCESS, but how to remove styling from unselected g's?
 //                                        $productStates = $productStates.attr("class","selectedClass");//class appears on tag but not actually styled with opacity change
 //                                        $productStates = $productStates.attr("class","selectedClass").siblings( "g" ).removeAttr( "class","selectedClass" );//class appears but quickly removes itself
-                                       
-                                       // check $productStates for existing classes
-                                       	$productStates.attr('class', function(index, classNames) {
-                                       	    // if there are existing classes
-											if (typeof classNames != 'undefined') {
-											    // return the existing classes and add selectedClass to the end of the list
-												return classNames + ' selectedClass';
-											} else {
-											    // otherwise, just add selectedClass
-												$productStates.attr('class', 'selectedClass');	
-											}
-										});
-                                       
-                                       // $productStates.attr("class","selectedClass");//.siblings( "g" ).removeAttr( "class","selectedClass" );//class appears on tag but not actually styled with opacity change
+                                        $productStates.attr("class","selectedClass");//.siblings( "g" ).removeAttr( "class","selectedClass" );//class appears on tag but not actually styled with opacity change
                                         //for line above, I indented one more tab in from where it was and now selectedClass is again appearing on tags but not actually styling the g's.
 //                                        $productStates = $productStates.addClass( "selectedClass" );//nothing. earlier today, style=("fill-opacity","0.1") got tacked onto appropriate g tags
 


### PR DESCRIPTION
Adjusted code so that the clicked class is correctly added only to the currently clicked state that has class="selectedClass". Also adjusted code to show/hide txtDOT panel, so that it hides when the drop-down changes and shows when the user clicks on an element with the selectedClass.

In exploreMap.html, I just commented out a curly brace that looked like it was missed when you commented other code.

Also updated EventHandlerConditionals.txt file with explanations of the changes made.
